### PR TITLE
Use the correct name of the company in the license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 hdisysteme
+Copyright (c) 2020 HDI Systeme AG
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
In this PR, I just correct the company name in the license ;-) 